### PR TITLE
Support Ubuntu 24.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        osversion: [ubuntu-24.04, ubuntu-22.04, ubuntu-20.04, ubuntu-18.04]
+        osversion: [ubuntu-24.04, ubuntu-22.04, ubuntu-20.04]
     steps:
       - uses: AutoModality/action-clean@v1
       - uses: actions/checkout@v2
@@ -64,7 +64,7 @@ jobs:
     runs-on: [self-hosted, linux, ARM64, dep-builder]
     strategy:
       matrix:
-        osversion: [ubuntu-22.04, ubuntu-24.04]
+        osversion: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
     steps:
       - uses: AutoModality/action-clean@v1
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
     runs-on: [self-hosted, linux, ARM64, dep-builder]
     strategy:
       matrix:
-        osversion: [ubuntu-22.04]
+        osversion: [ubuntu-22.04, ubuntu-24.04]
     steps:
       - uses: AutoModality/action-clean@v1
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        osversion: [ubuntu-22.04, ubuntu-20.04, ubuntu-18.04]
+        osversion: [ubuntu-24.04, ubuntu-22.04, ubuntu-20.04, ubuntu-18.04]
     steps:
       - uses: AutoModality/action-clean@v1
       - uses: actions/checkout@v2

--- a/docker/Dockerfile-ubuntu-24.04
+++ b/docker/Dockerfile-ubuntu-24.04
@@ -21,9 +21,9 @@ RUN cd Python-2.7.18 && ./configure --enable-optimizations && make altinstall
 RUN ln -s "/usr/local/bin/python2.7" "/usr/bin/python2"
 
 RUN wget --no-check-certificate -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-RUN add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16  main'
+RUN add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18  main'
 RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -qq \
-  clang-16 && apt-get clean -qq
+  clang-18 && apt-get clean -qq
 
 ADD ./entrypoint-build.sh /entrypoint.sh
 

--- a/docker/Dockerfile-ubuntu-24.04
+++ b/docker/Dockerfile-ubuntu-24.04
@@ -1,0 +1,30 @@
+FROM ubuntu:24.04
+RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -qq \
+  apt-transport-https \
+  apt-utils \
+  git \
+  wget \
+  python3 \
+  tar \
+  p7zip-full \
+  cmake \
+  software-properties-common \
+  build-essential \
+  curl zip unzip tar \  
+  pkg-config \
+  ninja-build \
+  && apt-get clean -qq
+
+RUN wget https://www.python.org/ftp/python/2.7.18/Python-2.7.18.tgz
+RUN tar xzf Python-2.7.18.tgz
+RUN cd Python-2.7.18 && ./configure --enable-optimizations && make altinstall
+RUN ln -s "/usr/local/bin/python2.7" "/usr/bin/python2"
+
+RUN wget --no-check-certificate -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+RUN add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16  main'
+RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -qq \
+  clang-16 && apt-get clean -qq
+
+ADD ./entrypoint-build.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
This PR aims to bring support of Ubuntu 24.04 on the `clang-binaries` side.

### Change List:
- Added Ubuntu 24.04 in workflow file
- Created Docker file for Ubuntu 24.04
- Update clang version to 18 for Ubuntu 24.04

